### PR TITLE
feat: add server route for posting

### DIFF
--- a/app/api/posts/route.js
+++ b/app/api/posts/route.js
@@ -1,8 +1,11 @@
 import { NextResponse } from 'next/server'
-import { supabaseServer } from '@/lib/supabaseServer'
+import { createServerClient } from '@/lib/supabaseServer'
 import { extractMentions } from '@/lib/utils'
 
+export const dynamic = 'force-dynamic'
+
 export async function POST(req){
+  const supabaseServer = createServerClient()
   const token = req.headers.get('Authorization')?.split(' ')[1]
   if(!token){
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })

--- a/app/api/posts/route.js
+++ b/app/api/posts/route.js
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server'
+import { supabaseServer } from '@/lib/supabaseServer'
+import { extractMentions } from '@/lib/utils'
+
+export async function POST(req){
+  const token = req.headers.get('Authorization')?.split(' ')[1]
+  if(!token){
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const { data: { user }, error: authError } = await supabaseServer.auth.getUser(token)
+  if(authError || !user){
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const { content, kind = 'text', media_url = null } = await req.json()
+  const { error } = await supabaseServer.from('posts').insert({ user_id: user.id, kind, content, media_url })
+  if(error){
+    return NextResponse.json({ error: error.message }, { status: 400 })
+  }
+  const names = extractMentions(content)
+  if(names.length){
+    const { data: profs } = await supabaseServer.from('profiles').select('id,username').in('username', names)
+    const notif = (profs||[]).map(p => ({ user_id: p.id, type: 'mention', payload: {} }))
+    if(notif.length){
+      await supabaseServer.from('notifications').insert(notif)
+    }
+  }
+  return NextResponse.json({ status: 'ok' })
+}

--- a/lib/supabaseServer.js
+++ b/lib/supabaseServer.js
@@ -1,12 +1,12 @@
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
-const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
-
-if(!supabaseUrl || !supabaseServiceKey){
-  throw new Error('Supabase server env vars missing')
+export function createServerClient(){
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if(!supabaseUrl || !supabaseServiceKey){
+    throw new Error('Supabase server env vars missing')
+  }
+  return createClient(supabaseUrl, supabaseServiceKey, {
+    auth: { persistSession: false }
+  })
 }
-
-export const supabaseServer = createClient(supabaseUrl, supabaseServiceKey, {
-  auth: { persistSession: false }
-})

--- a/lib/supabaseServer.js
+++ b/lib/supabaseServer.js
@@ -1,0 +1,12 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if(!supabaseUrl || !supabaseServiceKey){
+  throw new Error('Supabase server env vars missing')
+}
+
+export const supabaseServer = createClient(supabaseUrl, supabaseServiceKey, {
+  auth: { persistSession: false }
+})


### PR DESCRIPTION
## Summary
- add server-side Supabase client with service role key
- provide `/api/posts` route to insert posts and send mention notifications
- update `PostComposer` to call the new API instead of client-side inserts

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0b332390c83249ef9fd374c60cf25